### PR TITLE
Linted README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,28 +1,36 @@
-What is da.gd?
-==============
+# da.gd
+
+## What is da.gd?
 
 ![dagd-test](https://github.com/dagd/dagd/workflows/dagd-test/badge.svg?branch=master)
 
-da.gd is both a URL shortener and a collection of quick-info tools written in PHP. It allows you to use `curl` (or any http client) to quickly retrieve various kinds of information such as your IP, useragent, whois for a given domain or IP, DNS lookups, etc., from an easy-to-remember url.
+da.gd is both a URL shortener and a collection of quick-info tools written in
+PHP. It allows you to use `curl` (or any http client) to quickly retrieve
+various kinds of information such as your IP, useragent, whois for a given
+domain or IP, DNS lookups, etc., from an easy-to-remember url.
 
-The goal of this project is to just make an easy to use, little-of-everything tool that works on any device or in any script in any situation. So far, some interesting ideas have been requested (and implemented). If you have an idea for a feature you would like to see, please either (order of preference):
+The goal of this project is to just make an easy to use, little-of-everything
+tool that works on any device or in any script in any situation. So far, some
+interesting ideas have been requested (and implemented). If you have an idea
+for a feature you would like to see, please either (order of preference):
 
-- Fork, Add feature, Send pull request for review/merge.
-- Ask relrod to implement it on irc (freenode) via PM.
-- File it in the issue tracker.
+* Fork, Add feature, Send pull request for review/merge.
+* Ask relrod to implement it on irc (freenode) via PM.
+* File it in the issue tracker.
 
-Because a goal of this project is to have it work for many purposes/situations, I encourage feedback, ideas, participation, and interaction with this project. Have some fun with it :)
+Because a goal of this project is to have it work for many purposes/situations,
+I encourage feedback, ideas, participation, and interaction with this project.
+Have some fun with it :)
 
-What currently works?
-=====================
+## What currently works?
 
 `curl da.gd/help` will give you a list of what is currenly available
 on the live site.
 
-Getting a dev environment up
-============================
+## Getting a dev environment up
 
-da.gd is slightly annoying to set up, but there are now docker-compose files in place to make it easier.
+da.gd is slightly annoying to set up, but there are now docker-compose files in
+place to make it easier.
 You can get a quick development environment set up by doing this:
 
 * Ensure you have a working `docker-compose` or `podman-compose` setup.
@@ -30,12 +38,13 @@ You can get a quick development environment set up by doing this:
 * cd container
 * For docker-compose: `docker-compose up`
 * For podman-compose: `podman-compose up`
-* Go to http://localhost:8080/ in your regular browser.
+* Go to <http://localhost:8080/> in your regular browser.
 
-Note that the development environment is entirely ephemeral. Anything stored in the database will be lost when you `docker-compose down` or `podman-compose down`.
+Note that the development environment is entirely ephemeral. Anything stored in
+the database will be lost when you `docker-compose down` or
+`podman-compose down`.
 That is, **the files in `./container/` are not meant for production use**.
 
-License
-=======
+## License
 
 ASL 2.0. See `LICENSE` for more details.


### PR DESCRIPTION
I ran `README.markdown` through `mdl` and fixed it up a little bit. Nothing significant, mostly whitespace cleanup, 80-character line limits and such.

Prior to cleaning up, the output of `mdl` was as follows:

```
$ mdl README.markdown
README.markdown:28: MD004 Unordered list style
README.markdown:29: MD004 Unordered list style
README.markdown:30: MD004 Unordered list style
README.markdown:31: MD004 Unordered list style
README.markdown:32: MD004 Unordered list style
README.markdown:33: MD004 Unordered list style
README.markdown:6: MD013 Line length
README.markdown:8: MD013 Line length
README.markdown:14: MD013 Line length
README.markdown:25: MD013 Line length
README.markdown:35: MD013 Line length
README.markdown:16: MD025 Multiple top level headers in the same document
README.markdown:22: MD025 Multiple top level headers in the same document
README.markdown:38: MD025 Multiple top level headers in the same document
README.markdown:1: MD026 Trailing punctuation in header
README.markdown:16: MD026 Trailing punctuation in header
README.markdown:33: MD034 Bare URL used

A detailed description of the rules is available at https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
```

After cleanup, the output of `mdl` is:

```
$ mdl README.markdown
README.markdown:3: MD026 Trailing punctuation in header
README.markdown:25: MD026 Trailing punctuation in header

A detailed description of the rules is available at https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
```