### PR TITLE
Redescribe ISP application with newhelp API

### DIFF
--- a/src/applications/isp/DaGdISPController.php
+++ b/src/applications/isp/DaGdISPController.php
@@ -26,7 +26,7 @@ final class DaGdISPController extends DaGdController {
   }
 
   public function execute(DaGdResponse $response) {
-    $query = $this->getRequest()->getRouteComponent(1, client_ip());
+    $query = $this->getRequest()->getRouteComponent('ip', client_ip());
     $whois_client = new DaGdWhois($query);
     $response = $whois_client->performQuery();
     if (preg_match(

--- a/src/applications/isp/DaGdISPController.php
+++ b/src/applications/isp/DaGdISPController.php
@@ -2,17 +2,27 @@
 
 final class DaGdISPController extends DaGdController {
   public static function getHelp() {
-    return array(
-      'title' => 'isp',
-      'summary' => 'Return the name of your ISP, or that of the given IP.',
-      'path' => 'isp',
-      'examples' => array(
-        array(
-          'summary' => 'Return the name of your ISP'),
-        array(
-          'arguments' => array('69.171.234.21'),
-          'summary' => 'Return the name of the ISP of the given address.'),
-      ));
+    return id(new DaGdHelp())
+      ->setTitle('isp')
+      ->setDescription('Returns the name of your ISP, or that of the given IP.')
+      ->addPath(
+        id(new DaGdHelpPath())
+          ->setPath('isp')
+          ->setMethods(array('GET'))
+          ->addExample(
+            id(new DaGdHelpExample())
+              ->setCommentary(
+                'Return the name of your ISP.')))
+      ->addPath(
+        id(new DaGdHelpPath())
+          ->setPath('isp')
+          ->addPathArg('ip')
+          ->setMethods(array('GET'))
+          ->addExample(
+            id(new DaGdHelpExample())
+              ->addPathArg('69.171.234.21')
+              ->setCommentary(
+                'Return the name of the ISP of the given address.')));
   }
 
   public function execute(DaGdResponse $response) {

--- a/src/config.dev.php
+++ b/src/config.dev.php
@@ -121,7 +121,7 @@ class DaGdConfig {
       '/image/([0-9x*]+)(?:\.|/|)(\w+)?/?$' => array(
         'controller' => 'DaGdImageController',
       ),
-      '/isp(?:/?$|/([^/]+)/?$)' => array(
+      '/isp(?:/?$|/(?P<ip>[^/]+)/?$)' => array(
         'controller' => 'DaGdISPController',
       ),
       '/leftpad/([0-9]+)/(.+)/(.+)/?$' => array(

--- a/src/resources/help/DaGdHelp.php
+++ b/src/resources/help/DaGdHelp.php
@@ -72,20 +72,26 @@ final class DaGdHelp {
    */
   public function toOldHelp() {
     $examples = array();
-    $path_examples = $this->getPaths()[0]->getExamples();
-    if ($path_examples) {
-      foreach ($path_examples as $example) {
+
+    foreach ($this->getPaths() as $path) {
+      $path_examples = $path->getExamples();
+      if ($path_examples) {
+        foreach ($path_examples as $example) {
+          $examples[] = array(
+            'summary' => $example->getCommentary(),
+            'arguments' => $example->getPathArgs(),
+            'request' => $example->getGetArgs(),
+          );
+        }
+      } else if (empty($examples)) {
         $examples[] = array(
-          'summary' => $example->getCommentary(),
-          'request' => $example->getGetArgs(),
+          'summary' => null,
+          'arguments' => null,
+          'request' => null,
         );
       }
-    } else {
-      $examples[] = array(
-        'summary' => null,
-        'request' => null,
-      );
     }
+
     return array(
       'title' => $this->getTitle(),
       'summary' => $this->getDescription(),


### PR DESCRIPTION
Is this a good way of describing applications with an optional path parameter?

Seems to show up just fine:

![image](https://user-images.githubusercontent.com/40628/187268746-ac840348-78ca-4f1e-a26d-710fab119737.png)
