### PR TITLE
Use `$request->getClientIP()` instead of `client_ip()`

### DIFF
--- a/src/applications/commander/DaGdCommanderController.php
+++ b/src/applications/commander/DaGdCommanderController.php
@@ -30,7 +30,7 @@ final class DaGdCommanderController extends DaGdBaseClass {
   private function addCommand() {
     $query = $this->getWriteDB()->prepare(
       'INSERT INTO command_redirects(author_ip, command, url) VALUES(?, ?, ?)');
-    $ip = $request->getClientIP();
+    $ip = client_ip();
     $query->bind_param(
       'sss',
       $ip,

--- a/src/applications/commander/DaGdCommanderController.php
+++ b/src/applications/commander/DaGdCommanderController.php
@@ -30,7 +30,7 @@ final class DaGdCommanderController extends DaGdBaseClass {
   private function addCommand() {
     $query = $this->getWriteDB()->prepare(
       'INSERT INTO command_redirects(author_ip, command, url) VALUES(?, ?, ?)');
-    $ip = client_ip();
+    $ip = $request->getClientIP();
     $query->bind_param(
       'sss',
       $ip,

--- a/src/applications/isp/DaGdISPController.php
+++ b/src/applications/isp/DaGdISPController.php
@@ -26,7 +26,7 @@ final class DaGdISPController extends DaGdController {
   }
 
   public function execute(DaGdResponse $response) {
-    $query = $this->getRequest()->getRouteComponent('ip', $request->getClientIP());
+    $query = $this->getRequest()->getRouteComponent('ip', $this->getRequest()->getClientIP());
     $whois_client = new DaGdWhois($query);
     $response = $whois_client->performQuery();
     if (preg_match(

--- a/src/applications/isp/DaGdISPController.php
+++ b/src/applications/isp/DaGdISPController.php
@@ -26,7 +26,7 @@ final class DaGdISPController extends DaGdController {
   }
 
   public function execute(DaGdResponse $response) {
-    $query = $this->getRequest()->getRouteComponent('ip', client_ip());
+    $query = $this->getRequest()->getRouteComponent('ip', $request->getClientIP());
     $whois_client = new DaGdWhois($query);
     $response = $whois_client->performQuery();
     if (preg_match(

--- a/src/applications/metrics/DaGdMetricsController.php
+++ b/src/applications/metrics/DaGdMetricsController.php
@@ -48,7 +48,7 @@ final class DaGdMetricsController extends DaGdBaseClass {
 
     // Is the client allowed to be here?
     $allowed_ips = DaGdConfig::get('metrics.allowed_ips');
-    $client_ip = client_ip();
+    $client_ip = $request->getClientIP();
     if (!in_array($client_ip, $allowed_ips)) {
       return error403();
     }

--- a/src/applications/metrics/DaGdMetricsController.php
+++ b/src/applications/metrics/DaGdMetricsController.php
@@ -1,6 +1,6 @@
 <?php
-final class DaGdMetricsController extends DaGdBaseClass {
-  public function getHelp() {
+final class DaGdMetricsController extends DaGdController {
+  static public function getHelp() {
     // Private endpoint: Intentionally left out of /help
     return array();
   }
@@ -42,15 +42,15 @@ final class DaGdMetricsController extends DaGdBaseClass {
     return $dt;
   }
 
-  public function render() {
-    $category = $this->route_matches[1];
-    $specifier = $this->route_matches[2];
+  public function execute(DaGdResponse $response) {
+    $category = $this->getRequest()->getRouteComponent(1);
+    $specifier = $this->getRequest()->getRouteComponent(2);
 
     // Is the client allowed to be here?
     $allowed_ips = DaGdConfig::get('metrics.allowed_ips');
-    $client_ip = $request->getClientIP();
+    $client_ip = $this->getRequest()->getClientIP();
     if (!in_array($client_ip, $allowed_ips)) {
-      return error403();
+      return $this->error(403)->execute($response);
     }
 
     switch ($category) {
@@ -61,10 +61,10 @@ final class DaGdMetricsController extends DaGdBaseClass {
       case 'last_creation_epoch':
         return $this->shorten_last_action_epoch('creation');
       default:
-        return error404();
+        return $this->error(404)->execute($response);
       }
     default:
-      return error404();
+      return $this->error(404)->execute($response);
     }
   }
 }


### PR DESCRIPTION
I'm leaving the definition ~~even though it's unused,~~ in case DaGd Apps outside this repo reference it. But it could be deleted pretty soon, I think.

This requires porting to new-style controllers:

* Commander has pretty detailed inner routing, I'm reverting any change on it for today.
* I ported `metrics` to a new-style controller, and tested basic behavior locally.