### PR TITLE
ci: Reduce double-runs on PR branches

### DIFF
--- a/.github/workflows/dagd.yml
+++ b/.github/workflows/dagd.yml
@@ -2,6 +2,7 @@
 name: dagd-test
 on:
   push:
+    branches: [ master ]
   pull_request:
   schedule:
     - cron: 0 12 * * *


### PR DESCRIPTION
This change means that feature branches will only have a CI run once they have a PR created.