### PR TITLE
Allow `general.display_errors` to actually disable errors from rendering

### DIFF
--- a/src/resources/startup/DaGdStartup.php
+++ b/src/resources/startup/DaGdStartup.php
@@ -61,11 +61,9 @@ final class DaGdStartup {
     }
 
     $display_errors = DaGdConfig::get('general.display_errors');
-    if ($display_errors) {
-      ini_set('error_reporting', E_ALL);
-      ini_set('display_startup_errors', true);
-      ini_set('display_errors', true);
-    }
+    ini_set('error_reporting', E_ALL);
+    ini_set('display_startup_errors', $display_errors);
+    ini_set('display_errors', $display_errors);
 
     return $this;
   }


### PR DESCRIPTION
Historically, `general.display_errors` would force some ini settings on, so that errors and warnings would get rendered - this is useful sometimes in development.

But the setting never actually disabled warnings, if set to false. This means that instead of disabling warnings, we would just do whatever the system php.ini said.

With this change, we explicitly disable or enable those ini toggles, based on the value of `general.display_errors`.