### PR TITLE
Fix two deprecated uses of `null`

### DIFF
--- a/src/resources/html/DaGdTag.php
+++ b/src/resources/html/DaGdTag.php
@@ -30,6 +30,10 @@ final class DaGdTag {
   }
 
   protected function renderPotentialInnerTag($body) {
+    if ($body === null) {
+      return '';
+    }
+
     // This should let us compose tags that have already been constructed.
     if ($body instanceof DaGdTag) {
       return $body->renderSafe();
@@ -47,6 +51,17 @@ final class DaGdTag {
         $out .= $this->renderPotentialInnerTag($tag);
       }
       return $out;
+    }
+
+    if (!is_string($body)) {
+      if (is_numeric($body)) {
+        $body = (string)$body;
+      } else {
+        throw new Exception(
+          'Tag is not renderable. Body must be: null, DaGdTag, something that '.
+          'implements DaGdToTagInterface, a string, a number, or an array '.
+          'containing those things)');
+      }
     }
 
     if ($this->cdata) {

--- a/src/resources/html/DaGdTag.php
+++ b/src/resources/html/DaGdTag.php
@@ -60,7 +60,7 @@ final class DaGdTag {
         throw new Exception(
           'Tag is not renderable. Body must be: null, DaGdTag, something that '.
           'implements DaGdToTagInterface, a string, a number, or an array '.
-          'containing those things)');
+          '(containing those things)');
       }
     }
 

--- a/src/resources/http/DaGdRequest.php
+++ b/src/resources/http/DaGdRequest.php
@@ -56,8 +56,18 @@ class DaGdRequest {
 
   public function getRouteComponent($idx, $default = null, $urldecode = false) {
     $val = idx($this->route_matches, $idx, $default);
+    if ($val === null) {
+      // It's reasonable that we might get null here, possibly as a default.
+      // We special case it. But if we get something "fancier" back (that isn't
+      // a string) we'll throw below, because it's probably a bug.
+      return $val;
+    }
     if ($urldecode) {
-      return urldecode($val);
+      if (is_string($val)) {
+        return urldecode($val);
+      } else {
+        throw new Exception('Cannot urldecode non-string route component.');
+      }
     }
     return $val;
   }

--- a/src/resources/http/DaGdResponse.php
+++ b/src/resources/http/DaGdResponse.php
@@ -226,7 +226,8 @@ abstract class DaGdResponse {
     // session cookie keys.
     foreach ($this->getRequest()->getCookies() as $rk => $rv) {
       if (strpos($rk, 'DaGdSession_') === 0) {
-        setcookie($rk, null, 86401, '/', '', false, true);
+        setcookie($rk, '', 1, '/', '', false, true);
+        unset($_COOKIE[$rk]);
       }
     }
 

--- a/tests/dagd-test
+++ b/tests/dagd-test
@@ -192,6 +192,10 @@ final class TestCLI extends DaGdCLIProgram {
 
     /************ /up/xxxxxxx ************/
     $runner->arm(
+      id(new DaGdResponseCodeTest('/up/google.com', 200))
+        ->setAccept('text/html')
+        ->addGroup('up'));
+    $runner->arm(
       id(new DaGdRegexTest('/up/google.com', '@^200$@'))
         ->addGroup('up'));
     $runner->arm(
@@ -220,8 +224,8 @@ final class TestCLI extends DaGdCLIProgram {
     $runner->arm(
       id(new DaGdHeaderRegexTest(
         '/rhbz/1883609',
-	'Location',
-	'@^https://bugzilla\.redhat\.com/show_bug\.cgi\?id=1883609$@'))
+        'Location',
+        '@^https://bugzilla\.redhat\.com/show_bug\.cgi\?id=1883609$@'))
       ->addGroup('rhbz'));
     $runner->arm(
       id(new DaGdHeaderRegexTest(
@@ -547,6 +551,10 @@ final class TestCLI extends DaGdCLIProgram {
     /************ /roll/ ************/
     $runner->arm(
       id(new DaGdResponseCodeTest('/roll/3d', 404))
+        ->addGroup('roll'));
+    $runner->arm(
+      id(new DaGdResponseCodeTest('/roll/3d2', 200))
+        ->setAccept('text/html')
         ->addGroup('roll'));
     $runner->arm(
       id(new DaGdRegexTest('/roll/d9', '@^[0-9]$@'))


### PR DESCRIPTION
- In `DaGdTag`, if we are given a null, just render it as an empty string rather than running it through `htmlspecialchars()`. Also ensure that we have a string if we are going to try to treat something as a string (either by directly rendering it as unescaped CDATA or by passing it through `htmlspecialchars()`). Error if we get to that case and don't have a string.
- When expiring cookies (which we do on each request when we re-emit the session data), it is no longer allowed that we can pass in `null`, we are to use an empty string instead, per the docs. Also we should really unset the corresponding `$_COOKIE` key.