### PR TITLE
[shorten] Reject redirects based on Referer header

### DIFF
--- a/src/applications/shorten/resources/Blacklist.php
+++ b/src/applications/shorten/resources/Blacklist.php
@@ -208,7 +208,7 @@ class Blacklist {
     }
 
     $blacklisted_refs = DaGdConfig::get('shorten.referral_blacklist_strings');
-    foreach ($blacklist_refs as $string) {
+    foreach ($blacklisted_refs as $string) {
       if (strpos($this->referral, $string) !== false) {
         statsd_bump('shorturl_blacklisted_referral_string');
         statsd_bump('shorturl_blacklisted');

--- a/src/applications/shorten/resources/DaGdShortURLQuery.php
+++ b/src/applications/shorten/resources/DaGdShortURLQuery.php
@@ -156,8 +156,12 @@ final class DaGdShortURLQuery {
    * @return boolean
    */
   public function isBlacklisted($long_url, $is_create = false) {
+    $request = $this->controller->getRequest();
+    $referral = $request->getHeader('referer');
+
     return id(new Blacklist($long_url))
       ->setIsCreate($is_create)
+      ->setReferral($referral)
       ->setCache($this->controller->cache())
       ->check();
   }

--- a/src/config.dev.php
+++ b/src/config.dev.php
@@ -262,6 +262,15 @@ class DaGdConfig {
       'some.spam.url',
     ),
 
+    // We prevent redirects from other URL shorteners based on referral.
+    // This is the list of substrings we block on. Currently we only support
+    // substrings here because the primary usecase is to block other known URL
+    // shorteners.
+    'shorten.referral_blacklist_strings' => array(
+      // A non-existent default, mainly for integration tests
+      '/example.tld/',
+    ),
+
     // Regexes we whitelist on to avoid checking dnsbl.
     'shorten.longurl_whitelist' => array(),
 

--- a/tests/dagd-test
+++ b/tests/dagd-test
@@ -493,6 +493,12 @@ final class TestCLI extends DaGdCLIProgram {
         ->addGroup('noprod'));
 
     $runner->arm(
+      id(new DaGdResponseCodeTest('/g', 404))
+        ->setRequestHeader('Referer', 'https://example.tld/hey')
+        ->addGroup('shorten')
+        ->addGroup('noprod'));
+
+    $runner->arm(
       id(new DaGdResponseCodeTest('/s?url=https://some.spam.url', 400))
         ->addGroup('shorten')
         ->addGroup('noprod'));


### PR DESCRIPTION
This adds some blacklist logic to reject redirects based on the 'Referer' header. This can be used, for example, to reject redirects when a user comes from another URL shortener.